### PR TITLE
chore: setup EAS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,26 @@
 1. `yarn prebuild` to (re)generate native iOS and Android project files. Remember to always run this step when adding new dependencies with native modules.
 1. `yarn ios` to run the app on iOS
 1. `yarn android` to run the app on Android.
+
+# Creating a release
+
+### From GitHub
+
+Add any [tag](https://github.com/divvixyz/beefy/tags) and EAS will automatically start the release process.
+
+### Using EAS CLI
+
+Prerequisite: install EAS CLI and login to EAS. [Learn more](https://docs.expo.dev/build/setup/)
+
+Trigger a release
+
+```
+eas build --auto-submit --profile production --platform all
+```
+
+> [!IMPORTANT]
+> The CLI-triggered build uses the local project files. Ensure you have checked out the proper branch and it is in a good state for a build.
+
+### From the EAS dashboard
+
+Open the [app dashboard](https://expo.dev/accounts/divvi/projects/beefy) in EAS and press "Build from GitHub". [Learn more](https://docs.expo.dev/build/building-from-github/#build-using-the-expo-website)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 
 Add any [tag](https://github.com/divvixyz/beefy/tags) and EAS will automatically start the release process.
 
+### From the EAS dashboard
+
+Open the [app dashboard](https://expo.dev/accounts/divvi/projects/beefy) in EAS and press "Build from GitHub". [Learn more](https://docs.expo.dev/build/building-from-github/#build-using-the-expo-website)
+
 ### Using EAS CLI
 
 Prerequisite: install EAS CLI and login to EAS. [Learn more](https://docs.expo.dev/build/setup/)
@@ -23,7 +27,3 @@ eas build --auto-submit --profile production --platform all
 
 > [!IMPORTANT]
 > The CLI-triggered build uses the local project files. Ensure you have checked out the proper branch and it is in a good state for a build.
-
-### From the EAS dashboard
-
-Open the [app dashboard](https://expo.dev/accounts/divvi/projects/beefy) in EAS and press "Build from GitHub". [Learn more](https://docs.expo.dev/build/building-from-github/#build-using-the-expo-website)

--- a/app.json
+++ b/app.json
@@ -15,7 +15,12 @@
         "NSCameraUsageDescription": "Connecting your camera allows you to scan QR codes for transactions.",
         "NSUserTrackingUsageDescription": "We use the advertising identifier to accurately attribute app installs from ad campaigns.",
         "NSFaceIDUsageDescription": "This is required for you to use Face ID to secure your account.",
+        "NSContactsUsageDescription": "Adding your contacts makes it easy to send and request payments with your friends.",
+        "NSLocationWhenInUseUsageDescription": "This app requires location access to provide location-based features.",
         "ITSAppUsesNonExemptEncryption": false
+      },
+      "entitlements": {
+        "aps-environment": "production"
       }
     },
     "android": {

--- a/eas.json
+++ b/eas.json
@@ -1,6 +1,7 @@
 {
   "cli": {
-    "version": ">= 3.13.3"
+    "version": ">= 3.13.3",
+    "appVersionSource": "remote"
   },
   "build": {
     "e2e": {
@@ -10,6 +11,24 @@
       },
       "ios": {
         "simulator": true
+      }
+    },
+    "production": {
+      "node": "20.17.0",
+      "autoIncrement": true,
+      "distribution": "store"
+    }
+  },
+  "submit": {
+    "production": {
+      "android": {
+        "track": "internal",
+        "releaseStatus": "draft",
+        "changesNotSentForReview": true
+      },
+      "ios": {
+        "ascAppId": "6741587605",
+        "appleTeamId": "MW3VP6Y27R"
       }
     }
   }


### PR DESCRIPTION
## Description

This adds basic configuration for releases using [EAS Build and Submit](https://expo.dev/eas#build). 

It allows us to quickly build and submit the app to the stores with a minimal declarative configuration, lifting the need to create/maintain release pipelines ourselves.

## How to trigger a release (once this PR is merged)

### From GitHub

Add any [tag](https://github.com/divvixyz/beefy/tags) and EAS will automatically start the release process.

> [!TIP]
> This trigger is configured in the [EAS Settings](https://expo.dev/accounts/divvi/projects/beefy/github) and can be configured differently or turned off.

### Using CLI

Prerequisite: install EAS CLI and login to EAS. [Learn more](https://docs.expo.dev/build/setup/)

Trigger a release
```
eas build --auto-submit --profile production --platform all
```

> [!IMPORTANT]
The CLI-triggered build uses the local project files. Ensure you have checked out the proper branch and it is in a good state for a build.

### From the EAS dashboard

Open the [Beefy app dashboard](https://expo.dev/accounts/divvi/projects/beefy) in EAS and press "Build from GitHub". [Learn more](https://docs.expo.dev/build/building-from-github/#build-using-the-expo-website)

## Notes

### Build number

The build number is incremented automatically by EAS and is just a simple integer (1, 2, 3 etc). That's the EAS way of doing it. It's different from what we used to in Valora, where the build number is the last commit timestamp. Mimicking the same approach with EAS will require additional complexity, which we try to avoid.

The build number is incremented separately for Android and iOS builds.

We can set the build number using the EAS CLI: `eas build:version:set` when needed. [Learn more](https://docs.expo.dev/build-reference/app-versions/#developer-facing-build-version)

### Destinations

The builds are uploaded to the [Internal track](https://play.google.com/console/developers/5695387721434163201/app/4973393467170555451/tracks/internal-testing) in Google Play Store and to [TestFlight](https://appstoreconnect.apple.com/teams/2cab41f7-4867-490d-ae70-1574191aba0e/apps/6741587605/testflight/ios) in App Store Connect.

### Next steps

* Since EAS can manage Apple certificates only through login/password pair, we may consider to have some "service account" to provide for EAS through `EXPO_APPLE_ID` and `EXPO_APPLE_PASSWORD` secret env variables. That way EAS (supposedly) will be able to automatically rotate expired certificates.
* We may consider switching the E2E pipelines to [EAS Workflows](https://docs.expo.dev/eas/workflows/get-started/) since they provide the same managed build environment requiring very little configuration and come with a pre-packaged `build` job.