### PR TITLE
feat: display actions carousel on wallet tab only

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -114,6 +114,12 @@ const App = createApp({
   experimental: {
     earn: {
       showSafetyScoreOnPoolCard: true,
+    },
+    wallet: {
+      showActionsCarousel: true,
+    },
+    activity: {
+      hideActionsCarousel: true
     }
   }
 })

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "e2e:packager": "EXPO_PUBLIC_MOBILE_STACK_E2E=true yarn expo start"
   },
   "dependencies": {
-    "@divvi/mobile": "^1.0.0-alpha.9",
+    "@divvi/mobile": "^1.0.0-alpha.11",
     "@interaxyz/react-native-webview": "^13.13.4",
     "@react-native-async-storage/async-storage": "^2.1.0",
     "@react-native-clipboard/clipboard": "^1.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -855,10 +855,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@divvi/mobile@1.0.0-alpha.9":
-  version "1.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/@divvi/mobile/-/mobile-1.0.0-alpha.9.tgz#e2a55c997ac87b382aec261b7c3a70a3b29e696d"
-  integrity sha512-uTmGt62ESNelZ4bVtc19UonEawi1JD8Es8bSQTjN9fDdGkkN7oVukR4fOaPAvuShM1BmzB2WCrO28q4OiPAM3g==
+"@divvi/mobile@^1.0.0-alpha.11":
+  version "1.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/@divvi/mobile/-/mobile-1.0.0-alpha.11.tgz#1cad029ef4f90bf7a6a63d764b73950843ee299f"
+  integrity sha512-Kd9O308BfF3jmaQqkKZqx1V6wkhDab28cjQ9lTMlGb1CH1peCQT0YmVjWIFDoV9J/5bmfsoip6g2whkfaSWWQQ==
   dependencies:
     "@badrap/result" "~0.2.13"
     "@crowdin/ota-client" "^0.7.0"


### PR DESCRIPTION
### Description

Display the actions carousel on the wallet tab and remove the actions carousel from the activity tab.

| iOS Wallet Tab | iOS Activity Tab |
| ----- | ----- |
| ![](https://github.com/user-attachments/assets/1ac52cd0-7896-4054-a304-7e02450658d8) | ![](https://github.com/user-attachments/assets/680721e3-1a96-4b7b-b782-a70fcceeb383) |
